### PR TITLE
Add missing operators

### DIFF
--- a/languages/matlab/highlights.scm
+++ b/languages/matlab/highlights.scm
@@ -83,7 +83,7 @@ superclass: [(struct (identifier)) (identifier)] @type
 
 ;; Operators
 "=" @operator
-(operation [ ">"
+(operation [">"
             "<"
             "=="
             "<="
@@ -93,17 +93,23 @@ superclass: [(struct (identifier)) (identifier)] @type
             "~="
             "*"
             ".*"
+            "./"
             "/"
             "\\"
-            "./"
+            ".\\"
             "^"
             ".^"
-            "+"] @operator)
+            "+"
+            "-"
+            "'"] @operator)
 
 ;; boolean operator
 [
     "&&"
     "||"
+    "|"
+    "&"
+    "~"
 ] @operator
 
 ;; Number


### PR DESCRIPTION
Add some missing operators from
https://www.mathworks.com/help/matlab/matlab_prog/matlab-operators-and-special-characters.html documentation.

Still missing:
- Multi line comment
- Line continuation