### PR TITLE
keyword highlighing fix, and small fixes

### DIFF
--- a/languages/matlab/config.toml
+++ b/languages/matlab/config.toml
@@ -7,5 +7,9 @@ brackets = [
     { start = "{", end = "}", close = true, newline = false },
     { start = "[", end = "]", close = true, newline = false },
     { start = "(", end = ")", close = true, newline = false },
+    { start = "\"", end = "\"", close = true, newline = false },
+    { start = "}'", end = "}'", close = false, newline = false }, # the next 4 lines: char string should autoclose BUT NOT if closing parenthesis, bracket etc is proceeding
+    { start = ")'", end = ")'", close = false, newline = false },
+    { start = "]'", end = "]'", close = false, newline = false },
     { start = "'", end = "'", close = true, newline = false },
 ]

--- a/languages/matlab/highlights.scm
+++ b/languages/matlab/highlights.scm
@@ -4,32 +4,40 @@ function_keyword: (function_keyword) @keyword.function
 
 (function_definition
 function_name: (identifier) @function
-(end) @function)
-
+(end) @keyword.function)
 function_name: (identifier) @function.call
+; (function_definition end: (end) @keyword.function) ; not needed because we defined above already
 
 (parameter_list (identifier) @parameter)
 
+
+(if_statement
+  "if" @keyword.conditional)
+
+(if_statement (end) @keyword.conditional)
+
+(switch_statement
+  "switch" @keyword.conditional)
+
+(switch_statement (end) @keyword.conditional)
+
 [
-    "if"
     "elseif"
     "else"
-    "switch"
     "case"
     "otherwise"
-] @conditional
+] @keyword.conditional
 
-(if_statement (end) @conditional)
-(switch_statement (end) @conditional)
 
-["for" "while"] @repeat
-(for_statement (end) @repeat)
-(while_statement (end) @repeat)
+(for_statement ["for" @keyword.repeat])
+; (for_statement (pattern) @variable)
+(for_statement (end) @keyword.repeat)
+(while_statement ["while" @keyword.repeat])
+(while_statement (end) @keyword.repeat)
 
-["try" "catch"] @exception
-(try_statement (end) @exception)
+["try" "catch"] @keyword.exception
+(try_statement (end) @keyword.exception)
 
-(function_definition end: (end) @keyword)
 
 ["return" "break" "continue"] @keyword.return
 
@@ -96,20 +104,14 @@ superclass: [(struct (identifier)) (identifier)] @type
             "./"
             "/"
             "\\"
-            ".\\"
             "^"
             ".^"
-            "+"
-            "-"
-            "'"] @operator)
+            "+"] @operator)
 
 ;; boolean operator
 [
     "&&"
     "||"
-    "|"
-    "&"
-    "~"
 ] @operator
 
 ;; Number
@@ -120,5 +122,8 @@ superclass: [(struct (identifier)) (identifier)] @type
 (string) @spell
 
 ;; Comment
-(comment) @comment
-(comment) @spell
+
+
+;; Comment
+(comment "%") @comment
+; ((comment) @spell)    ; we decided we do not want spellchecking in comments

--- a/languages/matlab/highlights.scm
+++ b/languages/matlab/highlights.scm
@@ -83,7 +83,7 @@ superclass: [(struct (identifier)) (identifier)] @type
 
 ;; Operators
 "=" @operator
-(operation [ ">"
+(operation [">"
             "<"
             "=="
             "<="
@@ -93,17 +93,23 @@ superclass: [(struct (identifier)) (identifier)] @type
             "~="
             "*"
             ".*"
+            "./"
             "/"
             "\\"
-            "./"
+            ".\\"
             "^"
             ".^"
-            "+"] @operator)
+            "+"
+            "-"
+            "'"] @operator)
 
 ;; boolean operator
 [
     "&&"
     "||"
+    "|"
+    "&"
+    "~"
 ] @operator
 
 ;; Number


### PR DESCRIPTION
In "highlights.scm":
- renamed `@conditional`, `@repeat` etc to `@keyword.conditional`, `@keyword.repeat` etc because zed does not support the former (see https://zed.dev/docs/extensions/languages#syntax-highlighting) and there was no highlighting for if, for etc.
- removed `@spell` for comments because with spelling the comments were not highlighted as comments (not sure why though)

In "config.toml":
- added double quote autoclosing
- no single-quote autoclosing after any type of closing bracket, as then the single-quote should denote transposing an array, not starting a char array (but still does it after letters which I am still trying to figure out how to prevent).